### PR TITLE
Add new blog posts for AReaL v0.2 release and LLM development landscapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ blog/<post-slug>/index.mdx
 title: "Your Post Title"
 date: 2025-01-01
 authors: [inclusionai]
-tags: [model, release]
+tags: [Release, Insights]
 ---
 ```
 
@@ -54,9 +54,33 @@ tags: [model, release]
 | `title`           | Yes      | Post title (shown in listings and page `<title>`) |
 | `date`            | Yes      | Publication date (`YYYY-MM-DD`)                   |
 | `authors`         | Yes      | Author key(s) from `blog/authors.yml`             |
-| `tags`            | No       | Tag list for filtering                            |
+| `tags`            | No       | Tag list — certain tags control which site sections the post appears in (see below) |
 | `draft`           | No       | Set `true` to hide from build output              |
 | `custom_edit_url` | No       | Set `null` to hide the "Edit this page" link      |
+
+### Tag Reference
+
+Tags serve two purposes: they render as colored badges in the Blog listing and they route posts into dedicated sections on the [Research page](/research).
+
+**Special routing tags** (case-insensitive):
+
+| Tag         | Effect                                                                                |
+| ----------- | ------------------------------------------------------------------------------------- |
+| `Release`   | Post appears in the **Releases** section of the Research page (up to 5 most recent)   |
+| `Landscape` | Post appears in the **Landscapes** section of the Research page (up to 5 most recent) |
+
+**Badge color palette:**
+
+| Tag               | Color  |
+| ----------------- | ------ |
+| `Release`         | Blue   |
+| `Community`       | Green  |
+| `Insights`        | Purple |
+| `Tutorials`       | Amber  |
+| `Best Practice`   | Amber  |
+| *(anything else)* | Grey   |
+
+> Tags are matched case-insensitively for routing. Use title-case (`Release`, `Landscape`) by convention to match the badge display.
 
 ### 3. Add a Chinese translation (optional)
 

--- a/blog/areal-boba/index.mdx
+++ b/blog/areal-boba/index.mdx
@@ -1,0 +1,121 @@
+---
+title: "In RL we trust — AReaL v0.2 (Boba) Release"
+date: 2025-04-01
+authors: [inclusionai]
+tags: [release, insights]
+custom_edit_url: null
+---
+
+> Originally published on [Medium](https://medium.com/@ant-oss/in-rl-we-trust-the-advancement-brought-to-you-by-areal-v0-2-release-e63b5c7c49e5) by Ant Open Source.
+
+![AReaL v0.2 Boba](https://miro.medium.com/v2/resize:fit:1400/1*V1SMNBl2Bwo15c0xjuVsLg.jpeg)
+
+We are excited to release [AReaL v0.2 (Boba)](https://github.com/inclusionAI/AReaL), featuring three major milestones:
+
+- **[SGLang](https://github.com/sgl-project/sglang) Support**: With the addition of SGLang support and a series of engineering optimizations, AReaL v0.2 achieves a speed improvement of **1.5x** over AReaL v0.1 on 7B models.
+- **SOTA 7B Model**: AReaL's RL training becomes more stable and sample-efficient. We obtain a SOTA 7B model in mathematical reasoning, achieving pass@1 score of **61.9 on AIME24** and **48.3 on AIME25** respectively.
+- **Competitive 32B Model**: The highly competitive 32B model was trained with extremely low cost, achieving results comparable to QwQ-32B using **only 200 data samples**.
+
+![Performance comparison table](https://miro.medium.com/v2/resize:fit:1400/1*Lb5TDtPGukzGCDqB9gr-rQ.png)
+
+The table shows performance of [AReaL-boba-RL-7B](https://huggingface.co/inclusionAI/AReaL-boba-RL-7B) and [AReaL-boba-SFT-32B](https://huggingface.co/inclusionAI/AReaL-boba-SFT-32B). Note that we obtain SOTA 7B model using RL on math reasoning. We also train a highly competitive 32B model using only 200 data samples, replicating QwQ-32B's inference performance on AIME 2024.
+
+## Training Speed Comparison
+
+![AReaL-boba throughput comparison with v0.1.0](https://miro.medium.com/v2/resize:fit:1400/1*YTdEW-LgSRlAO_w06IMmrg.png)
+
+*AReaL-boba throughput comparison with v0.1.0*
+
+AReaL v0.2.0 features the following system optimizations:
+
+**Upgraded Generation Backend: vLLM 0.6.3 → SGLang v0.4.0**
+
+The generation backend has been upgraded leveraging SGLang's radix attention mechanism to significantly improve throughput in scenarios where multiple responses are sampled from the same prompt. SGLang automatically flushes radix caches upon weight updates, ensuring correctness in on-policy RL.
+
+**Optimized Training for Variable-Length Sequences & Large Batches**
+
+To handle variable sequence lengths efficiently, we eliminate padding and pack sequences into 1D tensors instead. A dynamic allocation algorithm optimally distributes sequences under a maximum token budget, balancing micro-batch sizes while minimizing the number of micro-batches. This approach maximizes GPU memory utilization.
+
+**High-Performance Data Transfer for 1K-GPU Scaling**
+
+AReaL employs NCCL with GPU-Direct RDMA (GDRDMA) over InfiniBand/RoCE, enabling direct GPU-to-GPU communication that bypasses costly CPU-mediated transfers and PCIe bottlenecks. This keeps generation-to-training data transfer overhead **below 3 seconds** even in a large 1,000-GPU cluster.
+
+## Training Recipe
+
+### SOTA 7B model using RL on math reasoning
+
+**Base Model**
+
+We use [R1-Distill-Qwen-7B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B) as our foundation model.
+
+**Dataset Curation**
+
+Our training dataset ([AReaL-boba-106k](https://huggingface.co/datasets/inclusionAI/AReaL-RL-Data/blob/main/data/boba_106k_0319.jsonl)) combines resources from multiple open-source projects:
+- [DeepScaleR](https://github.com/agentica-project/deepscaler)
+- [Open-Reasoner-Zero](https://github.com/Open-Reasoner-Zero/Open-Reasoner-Zero/)
+- [Light-R1](https://github.com/Qihoo360/Light-R1)
+- [DAPO](https://github.com/BytedTsinghua-SIA/DAPO)
+
+We enhanced this with challenging problems from [NuminaMath](https://huggingface.co/datasets/AI-MO/NuminaMath-CoT) (AoPS/Olympiad subsets) and [ZebraLogic](https://hf-mirror.com/datasets/WildEval/ZebraLogic).
+
+To maintain an appropriate difficulty level, overly simple questions were filtered out. Specifically, we generate 8 solutions per question using DeepSeek-R1-Distill-Qwen-7B and filter out questions where all solutions were correct.
+
+**Reward Function**
+
+We adopt a sparse sequence-level reward mechanism. The model is instructed to enclose the final answer within `\boxed{}`, and the boxed answer is then verified. Correct responses receive a reward of +5, while incorrect ones are penalized with -5.
+
+Notably, we observe that the KL reward can impair performance, particularly in long chain-of-thought training, so we set it to zero.
+
+**RL Algorithm**
+
+We employ Proximal Policy Optimization (PPO) as our training algorithm and remove the critic model to save compute. We set both the discount factor γ and the GAE parameter λ to 1. Such practices are also adopted by the [Open-Reasoner-Zero](https://github.com/Open-Reasoner-Zero/Open-Reasoner-Zero) project.
+
+**Token-Level Loss Normalization**
+
+Averaging the loss at the sequence level can underweight the overall contribution of longer texts. To address this, we normalize the loss at the token level, as also highlighted in [DAPO](https://github.com/BytedTsinghua-SIA/DAPO).
+
+**Rollout Strategy**
+
+During the rollout phase, we sample 512 questions per batch, and the LLM generates 16 responses per question — resulting in a total batch size of 8,192. To minimize output truncation, we set the maximum generation length to 27K tokens. In our experiment, the truncation rate remained below 5%.
+
+**Key Hyperparameters**
+
+![Key hyperparameters table](https://miro.medium.com/v2/resize:fit:1400/1*EfXM1It9EONq6utlXcU-RA.png)
+
+This configuration balances convergence speed with training stability.
+
+### Approaching QwQ-32B's performance using only 200 data samples
+
+For the 32B model size, we further refine the training data and release [AReaL-boba-SFT-200](https://huggingface.co/datasets/inclusionAI/AReaL-boba-Data/blob/main/AReaL-boba-SFT-200.jsonl), a high-quality dataset with only **200 data points**. Accompanied by relevant training scripts, we replicated **QwQ-32B**'s inference performance on **AIME 2024** via Supervised Fine-Tuning (SFT).
+
+### Evaluation Best Practices
+
+During evaluation, we use vLLM v0.6.3 as the generation framework. We recommend manually configuring the following options:
+
+```
+enforce_eager=True
+enable_chunked_prefill=False
+disable_custom_all_reduce=True
+disable_sliding_window=True
+```
+
+Following the practice of DeepSeek models, we incorporate a directive in the prompt: "Please reason step by step, and enclose your final answer in `\boxed{}`." To encourage long context reasoning, we also enforce that the model begins each response with `\n`.
+
+To ensure reliable pass@1 estimation, we:
+- Sample 32 answers per problem
+- Use temperature=0.6 and top_p=0.95 for SFT models
+- Maintain training temperature (1.0) for RL models
+
+## Conclusion & Future Work
+
+Our results demonstrate that **high-quality data is equally critical as algorithmic innovations**. When conducting RL training on a powerful base model, we require more challenging problems to facilitate learning. A straightforward strategy for data filtering involves removing problems that the base model consistently solves correctly across multiple sampling attempts.
+
+AReaL delivers stable and fast training with cutting-edge model performances. Since initial release, we've continuously improved system efficiency, training stability, and accessibility.
+
+Looking ahead, the AReaL team will:
+- Further optimize system performance
+- Introduce new features
+- Continue open-sourcing training data
+- Expand to broader reasoning tasks
+
+We believe these contributions lower the barrier for high-quality RL training while pushing the boundaries of reasoning capabilities. We welcome community feedback and collaboration to drive further progress.

--- a/blog/llm-landscape-2-0/index.mdx
+++ b/blog/llm-landscape-2-0/index.mdx
@@ -1,0 +1,140 @@
+---
+title: "Open Source LLM Development Landscape 2.0: 2025 Revisited"
+date: 2025-10-11
+authors: [inclusionai]
+tags: [Landscape, Insights]
+custom_edit_url: null
+---
+
+> Originally published on [Medium](https://medium.com/@ant-oss/open-source-llm-development-landscape-2-0-2025-revisited-d18cbf0a49c2) by Ant Open Source.
+
+Just over three months ago, Ant Open Source and InclusionAI jointly released the very [first Open Source LLM Development Landscape](https://medium.com/@ant-oss/open-source-llm-development-2025-landscape-trends-and-insights-4e821bceba68), along with a trend insights report. Our goal was simple: to highlight which projects in this fast-moving ecosystem are most worth tracking, using, and contributing to.
+
+That's why we're excited to unveil the **2.0 release of our Landscape** — a refreshed view of the ecosystem, built with even more insights and context. With the 2.0 release, we also refreshed our methodology for mapping the ecosystem, surfacing a wave of previously overlooked projects while removing others that didn't make the cut.
+
+![Open Source LLM Development Landscape 2.0](https://miro.medium.com/v2/resize:fit:1400/0*mdYvRumEN9k-oT7i.png)
+
+*Open Source LLM Development Landscape 2.0: [https://antoss-landscape.my.canva.site/](https://antoss-landscape.my.canva.site/)*
+
+The updated landscape is organized into two major directions: **AI Infra** and **AI Agents**. Drawing on community data, we identified and included **114 of the most prominent open source projects**, spanning **22 distinct technical domains**.
+
+For **2.0**, we shifted to using the global **GitHub OpenRank rankings** directly. From the top down, we filtered projects by their descriptions and tags to identify those belonging to the LLM ecosystem, and gradually refined the scope. Only projects with an **OpenRank score of 50 or higher** are included.
+
+> Note: By installing the [HyperCRX](https://github.com/hypertrons/hypertrons-crx) browser extension, you can view an open-source project's OpenRank trend in the bottom-right corner of its GitHub repository page.
+
+Compared with the 1.0 release, this new 2.0 Landscape brings in **39 fresh projects** — about **35% of the total list**. On the other hand, **60 projects from the first version have been dropped**, mostly because they fell below the new bar. Even if we include the dropped projects, the **median "age"** of all projects is just **30 months** — barely two and a half years old. **62% of these projects were launched after the "GPT moment"** (October 2022).
+
+These projects have drawn participation from 366,521 developers worldwide. Among those with identifiable locations, about **24%** are based in the United States, **18%** in China, followed by India (8%), Germany (6%), and the United Kingdom (5%).
+
+## Global Developer Contribution
+
+Across the **170+ open source projects** covered in both Landscape versions, we observed over **360K GitHub** accounts engaging through issues or pull requests. Among these, we identified **124,351 developers** with parseable location data.
+
+Overall, U.S. accounts for **37.4%** of contributions, with China at **18.7%**, putting their combined share above 55%. Germany drops sharply to 6.5% in third place.
+
+![Top 10 Countries by Contribution](https://miro.medium.com/v2/resize:fit:1400/1*oEypNq8CfLjbfNuqVX0hsA.png)
+
+*Top 10 Countries by Contribution in Open-Source LLM Ecosystem*
+
+Looking across technical fields:
+- In **AI Infra**, U.S. and China account for **over 60%** of contributions
+- In **AI Data**, participation is more globally distributed, with several European countries ranking in the global top 10
+- In **AI Agents**, U.S. and Chinese developers contribute **24.6%** and **21.5%** respectively
+
+## Large Models Landscape 2025
+
+Outside of the open source development ecosystem, large models themselves are being released at a rapid pace. A few interesting observations:
+
+- **MoE Takes Center Stage**: Flagship models like DeepSeek, Qwen, and Kimi have all adopted Mixture of Experts (MoE) architecture — sparse activation enabling trillion-parameter giants like K2, Claude Opus, and o3.
+- **Reinforcement Learning Boosts Reasoning**: DeepSeek R1 combines large-scale pretraining with RL-based post-training, making reasoning the signature feature for flagship model releases in 2025. Series like Qwen, Claude, and Gemini have begun integrating "hybrid reasoning" modes.
+- **Multimodality Goes Mainstream**: Most 2025 releases focus on language, image, and speech interaction, though specialized vision-only and speech-only models have also emerged.
+
+## From Landscape to Tech Trends
+
+### Large Models Development Keywords
+
+We extracted keywords from the GitHub descriptions and topics of every open-source project in the Landscape. The most frequent keywords are: **AI (126), LLM (98), Agent (81), Data (79), Learning (44), Search (36), Model (36), OpenAI (35), Framework (32), Python (30), MCP (29).**
+
+![Keyword cloud](https://miro.medium.com/v2/resize:fit:1400/0*339JsW-VXN2jj7Ck.png)
+
+### Top 10 Open Source Projects
+
+The top 10 projects by OpenRank span nearly the entire chain: from foundational compute and frameworks like **PyTorch** and **Ray**, to training data pipelines such as **Airflow**, to high-performance serving engines like **vLLM**, **SGLang**, and **TensorRT-LLM**. On the application side: **Dify**, **n8n**, **Gemini CLI**, and **Cherry Studio**.
+
+![Top 10 by OpenRank](https://miro.medium.com/v2/resize:fit:1400/0*y-AVRRV3E60y5JPH.png)
+
+> Note: All data is as of August 1, 2025
+
+Looking at the forces behind these projects:
+- **Academia**: Projects like vLLM, SGLang, and Ray emerged from UC Berkeley's labs under Ion Stoica
+- **Tech giants**: Meta, Google, NVIDIA hold or shape critical positions in the stack
+- **Indie teams**: Smaller teams like Dify and Cherry Studio are innovating rapidly near the application layer
+
+### Redefining Open Source in the LLM Era
+
+Veterans familiar with open source licensing might feel alarm when looking at licenses adopted by today's top projects. While most projects still rely on permissive licenses like **Apache 2.0 or MIT**, several high-profile cases stand out:
+
+- **Dify's "Open Source License"**: Based on Apache 2.0 but restricts unauthorized multi-tenant operation and prohibits removing logos/copyright notices.
+- **n8n's "Sustainable Use License"**: Allows free use and modification but restricts commercial redistribution.
+- **Cherry Studio's "User-Segmented Dual Licensing"**: AGPLv3 for ≤10-person orgs; commercial license required for larger orgs.
+
+At the same time, **GitHub has evolved into a stage for product operations**. Many products with closed-source codebases — like Cursor and Claude Code — still maintain GitHub presences primarily for **collecting user feedback**, often accumulating huge numbers of stars despite providing little or no actual source code.
+
+### Shifting Trends Across Technical Domains
+
+**AI Coding, Model Serving, and LLMOps** are all on an upward trajectory. **AI Coding stands out with a steep growth curve** — once again confirming that boosting R&D efficiency with AI is the application scenario truly taking root in 2025.
+
+On the other hand, **Agent Frameworks and AI Data** have shown noticeable declines. The drop in Agent Frameworks is closely tied to reduced community investment from once-dominant projects like **LangChain, LlamaIndex, and AutoGen**.
+
+### Projects on The Brink List
+
+Some projects didn't make it into this version but still show strong potential. Among the projects that dropped out, many appear to be heading toward the "AI graveyard":
+
+- **Manus** briefly exploded in popularity, inspiring open-source forks like OpenManus and OWL, but the hype proved short-lived.
+- **NextChat**, one of the earliest popular LLM client apps, lost ground to newer entrants like **Cherry Studio** and **LobeChat**.
+- **Bolt.new**, once a trendy full-stack web dev tool, was open-sourced as template repos with little external contribution.
+- **MLC-LLM** and **GPT4All** were once widely used for on-device deployment, but **Ollama emerged as the clear winner** in this niche.
+- **FastChat** evolved into the more successful **SGLang** and **LMArena** platforms.
+- **Text Generation Inference (TGI)** was gradually abandoned by Hugging Face as performance fell behind vLLM and SGLang.
+
+## 100 Days of Change and Continuity
+
+Beyond project reshuffling, the jump from 1.0 to 2.0 brought refinements to how we define and describe the ecosystem. The broad categories of "Infrastructure" and "Application" were restructured into three clearer domains: **AI Infra, AI Agent, and AI Data**.
+
+### New Fields and Projects Entering the Spotlight
+
+The most notable shifts are happening in the **Agent layer**, with high-profile projects emerging across **AI Coding, chatbots, and development frameworks**. Two projects stand out for their connection to **embodied intelligence**: [AI XiaoZhi](https://github.com/78/xiaozhi-esp32) (ESP32-based AI voice interaction device) and [Genesis](https://github.com/Genesis-Embodied-AI/Genesis) (robotics and embodied simulation platform).
+
+On the **Infra side**, the biggest change is the integration of "model operations" into a more holistic concept: **LLMOps** — spanning Observability (Langfuse, Phoenix), Evaluation & Benchmarking (Promptfoo), and Agentic Workflow Runtime Management (1Panel, Dagger).
+
+**Top 10 Active Newcomers**: Notably, **Gemini CLI** ranked 3rd and **Cherry Studio** ranked 7th across all projects in the Landscape — a remarkable showing for first-time entrants.
+
+![Top 10 new projects](https://miro.medium.com/v2/resize:fit:1400/0*vWMk5jSQTO7VDlQT.png)
+
+> Note: All data is as of August 1, 2025
+
+### What Hasn't Changed: Rise, Fall, and the Cycle of Momentum
+
+Among the new wave, **OpenCode** was positioned from day one as a **100% open-source alternative to Claude Code**. Other newcomers highlight how major players are laying out strategies across model serving, agent toolchains, and AI coding:
+
+- **Dynamo** supports vLLM, SGLang, and TensorRT-LLM while being optimized for NVIDIA GPUs
+- **adk-python** and **openai-agents-python** are agent builders packaged for Gemini and OpenAI models
+- **Gemini CLI** and **Codex CLI** bring autonomous code understanding directly into the command line
+
+The projects showing the most noticeable growth include **TensorRT-LLM**, **verl** (RL framework from ByteDance), **OpenCode**, and **Mastra** (TypeScript/JavaScript Agent framework). In contrast, the sharpest declines include **Eliza, LangChain, LlamaIndex**, and **AutoGen**.
+
+## Core Tech Trends: Serving, Coding, and Agents
+
+### Serving: Making Models Truly Usable
+
+Model serving is about running a trained model in a way that applications can reliably call — not just "can it run?" but "can it run efficiently, controllably, and at scale?" Since 2023, rapid progress has made serving the **critical middleware layer** connecting AI infrastructure with applications.
+
+### Coding: The New Developer Vibe
+
+AI Coding has evolved far beyond basic code completion, now encompassing multimodal support, contextual awareness, and collaborative workflows. **CLI tools** like Gemini CLI and OpenCode leverage large models to transform developer intent into faster coding. **Plugin-based tools** such as Cline and Continue integrate into existing development platforms.
+
+### Agent: Building Toward AGI
+
+2025 is widely considered the year AI applications truly land. The open-source ecosystem has expanded with projects specializing in different components: **Mem0** (memory), **Browser-Use** (tool use), **Dify** (workflow execution), and LobeChat (interaction interface) — together shaping a more complete foundation for building autonomous AI systems.
+
+More on GitHub: [https://github.com/antgroup/llm-oss-landscape](https://github.com/antgroup/llm-oss-landscape)

--- a/blog/llm-landscape-2025/index.mdx
+++ b/blog/llm-landscape-2025/index.mdx
@@ -1,0 +1,152 @@
+---
+title: "Open Source LLM Development 2025: Landscape, Trends and Insights"
+date: 2025-06-11
+authors: [inclusionai]
+tags: [Landscape, Insights]
+custom_edit_url: null
+---
+
+> Originally published on [Medium](https://medium.com/@ant-oss/open-source-llm-development-2025-landscape-trends-and-insights-4e821bceba68) by Ant Open Source.
+
+**「AI Surpasses Cloud Native as the Most Influential Tech Domain」**
+
+According to [OpenRank](https://open-digger.cn/docs/user_docs/metrics/global_openrank) data from [OpenDigger](https://github.com/X-lab2017/open-digger), AI surpassed Cloud Native in 2023 to become the most influential technology domain in terms of community collaboration on GitHub. AI's total influence score overtook Frontend technologies in 2017, accelerated post-2022, and surpassed the declining Cloud Native in 2023 to claim the top spot.
+
+![AI surpasses Cloud Native](https://miro.medium.com/v2/resize:fit:1400/0*tj8ORLVViWg-PIda.png)
+
+## The LLM Development Ecosystem: A Snapshot
+
+![LLM Development Landscape](https://miro.medium.com/v2/resize:fit:1400/0*SO1BJccf--QanEGY.png)
+
+*[https://antoss-landscape.my.canva.site](https://antoss-landscape.my.canva.site)*
+
+In February 2025, DeepSeek sparked a surge in the LLM development ecosystem. GitHub's Weekly Trending List reached a peak where **94% of the listed repositories were AI-related**. This ecosystem is incredibly new and evolving fast — over the past three months, 60% of LLM-related projects that appeared on GitHub Trending were emerged after 2024, and nearly 21% were created in just the last six months.
+
+We build the landscape by first selecting well-known AI projects (e.g., PyTorch, LangChain, vLLM) as seed nodes. By analyzing developer collaboration relationships across "related" GitHub projects, we explored multiple facets of the ecosystem. We rely on the **OpenRank influence metric** developed by X-lab at East China Normal University — only projects with an **average monthly OpenRank score exceeding 10 in year 2025** are included.
+
+As of May 2025, the Open Source LLM Development Landscape 2025 includes **135 projects across 19 technical domains**, spanning both Agent application layers and model infrastructure layers.
+
+Below are the details of projects ranked in the Top 20 of OpenRank:
+
+![Top 20 by OpenRank](https://miro.medium.com/v2/resize:fit:1400/0*-ohKAIcFTyBYHR-z.png)
+
+By stack ranking the year-over-year absolute changes in OpenRank between 2024 and 2025, we converged on 3 key observations:
+
+- **Model Training Frameworks**: PyTorch remains the undisputed leader. Baidu's PaddlePaddle saw a 41% drop in OpenRank compared to the previous year.
+- **Efficient Inference Engines**: The high-performance inference engines vLLM and SGLang have undergone rapid iterations, ranking first and third in OpenRank value growth. Their superior GPU inference performance made them the most popular choices for enterprise-level LLM deployment.
+- **Low-Code Application (Agent) Development Frameworks**: Agent platforms like Dify and RAGFlow, which integrate RAG-based knowledge retrieval, are experiencing rapid growth as they meet the red-hot demand for quickly building AI applications. Notably, both platforms are strong projects emerging from China's developer community.
+
+After observing over 100 open-source projects, we've reached a pivotal point to make a bold claim: **the LLM development ecosystem operates like a real-world Hackathon** — developers, empowered by AI, now operate as "super individuals" to rapidly build open-source projects around trending topics, with cycles of rapid creation and dissolution driven by speed and iteration.
+
+### Key hackathon observations:
+
+**1. Developers keep building OSS clones for rapid adoption**
+
+When closed-source projects like Devin, Perplexity, and Manus brought shockwaves to the industry, developers quickly replicated open-source versions:
+
+- **Devin & OpenDevin**: In March 2024, Xingyao Wang (PhD candidate at UIUC) launched OpenDevin. Within a month, its OpenRank skyrocketed to 190. The project was rebranded as OpenHands and evolved into All Hands AI.
+- **Perplexity & Perplexica**: Independent developer *ItzCrazyKns* created Perplexica in 2024 as an open-source alternative. It amassed 22K GitHub stars but OpenRank plateaued around 25.
+- **Manus & OpenManus**: In March 2025, as Manus went viral, DeepWisdom pulled off a "3-hour replication" with OpenManus, garnering 8K stars on its first day.
+
+**2. Ephemeral technical experiments often end up in the AI graveyard**
+
+Out of 5,079 AI tools recorded by Dang AI, 1,232 have been archived/abandoned. Dang AI even created an "[AI Graveyard](https://dang.ai/ai-graveyard)." We've curated an "Open-Source AI Graveyard" for projects that gained massive attention upon launch but became inactive — including BabyAGI (April 2023) and Swarm (OpenAI, formally discontinued March 2025).
+
+**3. Model capabilities are reshaping application scenarios**
+
+- **The decline of AI Search projects**: The generalization of model capabilities (GPT-4, Gemini 2.0) is squeezing the market for specialized search tools like Morphic.sh and Scira.
+- **The rise of AI Coding projects**: Claude 3.7 Sonnet's prowess in coding ushered in "Vibe Coding." IDE plugins like Continue and Cline are thriving open-source options, each with over 3,000 community contributors and steadily rising OpenRank scores.
+
+**4. Dynamic competition across ecosystem niches**
+
+- **Divergent trajectories of Agent Frameworks**: Application platforms like Dify diverged sharply from development frameworks like LangChain. Special mention: [DB-GPT](https://github.com/eosphoros-ai/DB-GPT), an open-source project initiated by Ant Group, integrates AI application development into big data application scopes.
+- **The rise of Reinforcement Learning**: DeepSeek-R1's "Aha Moment" demonstrated RL's effectiveness as a post-training approach. Frameworks like Verl and OpenRLHF have seen remarkable growth. In February, [inclusionAI](https://github.com/inclusionAI/AReaL) fully open-sourced their RL framework [AReaL](https://github.com/inclusionAI/AReaL), designed to train large inference models that anyone can reproduce.
+- **The blurring of Technical Boundaries**: Vector databases, once standalone, now compete with traditional big data systems (e.g., OceanBase adding vector storage support) while maintaining a delicate ecological equilibrium.
+
+## Now, the Technical Trends in LLM Open-Source Development Ecosystems
+
+We observed and summarized **7 relatively clear technical trends** including emerging paradigms such as **Agent Frameworks**, AI-native communication protocols like **MCP**, and **Coding Agents** at the application layer.
+
+![7 Technical Trends](https://miro.medium.com/v2/resize:fit:1400/0*YHWcizFBaWdzuTpP.png)
+
+### 1. The Agent Frameworks Boom Diverged in 2025
+
+From 2023 to 2024, "all-in-one" frameworks like LangChain dominated with their pioneering task orchestration capabilities. A huge number of new Agent development frameworks emerged, many focusing on specific features such as tool calling, RAG integration, long-context memory, or ReAct planning.
+
+By the second half of 2024, only a few new frameworks entered the ecosystem. As the initial hype faded, early market leaders like LangChain were gradually declining due to steep learning curves.
+
+Entering 2025, the market showed signs of divergence: platforms like Dify and RAGFlow became extremely popular by offering low-code workflows and enterprise-grade service deployments. In contrast, development frameworks like LangChain and LlamaIndex have been steadily losing ground.
+
+Dify has accurately captured enterprise user needs — offering intuitive visual workflow orchestration, comprehensive enterprise-grade security, and significantly lowering the technical barrier for amateur users.
+
+### 2. Standard Protocol Layer: The Strategic Battleground
+
+- **2022**: Wild West Era — ad-hoc prompt engineering for tool interaction.
+- **2023**: OpenAI's GPT4-0613 introduced Function Calling with standardized API.
+- **2024**: Anthropic's **Model Context Protocol (MCP)**, open-sourced November 2024, standardized agent-tool communication. By Q1 2025, MCP became the de facto standard.
+- **2025**: Protocol "War" begins:
+  - April: Google open-sourced the **Agent2Agent (A2A)** protocol for communication between multiple agents.
+  - May: CopilotKit launched the **Agent-User Interaction (AG-UI)** protocol with 2.2K GitHub stars in its first week.
+
+The emergence of MCP, A2A, and AG-UI signals LLM applications evolving toward a microservices architecture. The open-source ecosystem will become the battlefield of both standards and their reference designs.
+
+### 3. The Irresistible Vibe Coding Software Development Paradigm
+
+When Andrej Karpathy introduced the term "vibe coding," it seemed to capture "The Trend" in the upcoming productivity domain. Our research reveals a market pattern:
+
+**Major tech companies** have rapidly entered AI coding primarily with closed-source offerings: GitHub Copilot, Amazon Q Developer, Huawei's CodeArts Snap, Alibaba's Tongyi Lingma, ByteDance's Trae, and Ant Group's CodeFuse.
+
+**Startup ventures and small teams** have demonstrated remarkable agility. A prime example is Continue's "continuedev," which gained substantial attention through lean operations and flexible innovation. The sector's potential was endorsed by OpenAI's reported $3 billion acquisition offer for Windsurf.
+
+AI coding tools are advancing beyond basic snippet generation to tackle full-scale development workflows, though substantial challenges remain in semantic validation, multi-language coordination, and security-sensitive code generation.
+
+### 4. The Shifting Boundaries of Vector Indexing and Storage
+
+The evolution of vector databases can be described as a journey **"from explosive hype to rational consolidation."** Around February 2023, projects like Qdrant and Chroma saw an unprecedented surge, amassing over 5,000 GitHub stars. However, this initial frenzy **failed to sustain long-term momentum.**
+
+Several factors contributed to equilibrium:
+1. Closed-source commercial competitors like Pinecone demonstrated strong product capabilities.
+2. Traditional databases (PostgreSQL, MongoDB Atlas, ElasticSearch) introduced vectorization via plugins like pgvector.
+3. The OpenCore model prioritizes ecosystem expansion over community metrics.
+
+Despite these pressures, large-scale enterprise demands for cloud-native scalability and compliance still favor specialized vector databases. MilVus, under neutral LF AI & Data stewardship, has consistently maintained a stable leading position.
+
+### 5. The Evolution of Multimodal Data Governance in the Age of LLMs
+
+In data lake table formats, **Apache Iceberg, Apache Hudi, Apache Paimon**, and **Delta Lake** have formed a "quadropoly." Iceberg has solidified its position as the universal framework, while Hudi and Paimon excel in real-time incremental processing.
+
+The metadata governance and data catalog space sees **OpenMetadata** and **DataHub** maintaining leadership, with newcomers like **Apache Gravitino** and **Unity Catalog** emerging as potential disruptors. These tools are expanding to include unstructured data and AI assets.
+
+### 6. The Ongoing Horse Racing in Model Serving and Inference
+
+Three critical factors have emerged as core deal-makers or deal-breakers: **inference efficiency, resource utilization, and deployment flexibility.** The Top 10 ranking list reshuffles constantly, with contenders like Tsinghua University's KTransformers and NVIDIA's Dynamo continually challenging the status quo.
+
+A potential duopoly is forming: **vLLM and SGLang, currently the two most prominent inference engines in the LLM space.** In Q1 2025, vLLM's OpenRank grew at 17%, while SGLang surged to 31%.
+
+This duel carries notable academic pedigree: UC Berkeley, birthplace of Spark and Ray, again demonstrates its open-source alchemy. vLLM originated from Berkeley's SkyLab; SGLang from LMSYS, the multi-university research consortium that created Chatbot Arena.
+
+Other notable engines:
+- **Ollama & llama.cpp**: The lightweight powerhouses for edge inference and on-premise deployment
+- **KTransformers**: Enabled running full 671B parameter models (DeepSeek-R1/V3) on consumer hardware with 3–28x speedups, triggering a 34x OpenRank spike
+
+### 7. The PyTorch-Centric Training Ecosystem
+
+PyTorch has undeniably become the dominant force and de facto standard in LLM development. Its modular, lightweight design propelled it past TensorFlow in 2020, while TensorFlow, MXNet, and Caffe faded into obsolescence.
+
+In September 2022, Meta transferred PyTorch's governance to the Linux Foundation, establishing the PyTorch Foundation. Through PyTorch's nearly overwhelming ecosystem gravitational pull, this sub-foundation has grown into a powerful umbrella organization:
+- March 2025: Inference engine **SGLang** joined the PyTorch ecosystem
+- May 2025: **vLLM** and distributed training platform **DeepSpeed** joined the PyTorch Foundation
+
+Community data still reveals Meta's substantial behind-the-scenes influence: the repository's top contributors are all identifiable Meta staff, and over 9,000 pull requests (9% of all PRs) carry the "fb-exported" label.
+
+## Conclusion
+
+Ant Group's Open Source team initiated this landscape project to understand the full picture of the LLM development ecosystem, including emerging trends and cutting-edge popular projects. One of our missions is to leverage insights from the open-source community to guide Ant Group's architectural and technological decisions.
+
+This report reflects Ant Group's perspective as a technology enterprise, utilizing X-lab's OpenRank evaluation metrics alongside extensive consultations with technical experts and open-source community developers.
+
+> Full Author List:
+> Xiaoya Xia, Sikang Bian, Chao Dong, Xu Wang (AntOSS)
+> Shengyu Zhao, Fanyu Han, Jiaheng Peng, Zhen Zhang, Wei Wang (X-lab)
+
+More on GitHub: [https://github.com/antgroup/llm-oss-landscape](https://github.com/antgroup/llm-oss-landscape)

--- a/blog/llm-landscape-vllm-sgl/index.mdx
+++ b/blog/llm-landscape-vllm-sgl/index.mdx
@@ -1,0 +1,96 @@
+---
+title: "The Community Stories of vLLM and SGLang"
+date: 2025-12-17
+authors: [inclusionai]
+tags: [Landscape, Insights]
+custom_edit_url: null
+---
+
+> Originally published on [Medium](https://medium.com/@ant-oss/the-community-stories-of-vllm-and-sgl-d4675e77da6a) by Ant Open Source.
+
+## First, what is LLM inference?
+
+Training large language models (LLMs) attracts attention for its massive compute demands and headline-making breakthroughs; however, what ultimately determines their real-world practicality and broad adoption is the efficiency, cost, and latency of the inference stage. Inference is the process by which a trained AI model applies what it has learned to new, unseen data to make predictions or generate outputs. For LLMs, this means accepting a user prompt, computing through the model's vast network of parameters, and ultimately producing a coherent text response.
+
+The core challenge in LLM inference is deploying models with tens to hundreds of billions of parameters under tight constraints on latency, throughput, and cost. It is a complex, cross-stack problem spanning algorithms, software, and hardware. **Among open-source inference engines, vLLM and SGLang are two of the most closely watched projects.**
+
+### From academic innovation to a community-driven open-source standard-bearer
+
+![vLLM and SGLang history](https://miro.medium.com/v2/resize:fit:1400/1*t4rMoao-chJR9oMZI9r_7g.jpeg)
+
+vLLM traces its roots to a 2023 paper centered on the PagedAttention algorithm, "Efficient Memory Management for Large Language Model Serving with PagedAttention." vLLM's breakthrough wasn't a brand-new AI algorithm; instead, it borrowed paging and cache management ideas from operating systems to fine-grain memory management, laying the groundwork for high-throughput request handling via its **PagedAttention** mechanism. vLLM also embraced and advanced several industry techniques, such as **Continuous Batching** first described in the paper "Orca: A Distributed Serving System for Transformer-Based Generative Models."
+
+![vLLM star growth](https://miro.medium.com/v2/resize:fit:1400/0*Dwx36hMXk1FgGJ6p.png)
+
+*(Source: star-history)*
+
+vLLM delivered striking gains: compared with a Hugging Face Transformers–based backend, vLLM handled up to 5× the traffic and boosted throughput by as much as 30×. Within less than half a year it amassed tens of thousands of stars; today, over ten thousand contributors have engaged in issue/PR discussions, nearly 2,000 have submitted PRs, and on average at least 10 new issues are filed daily.
+
+SGLang originated from the paper "SGLang: Efficient Execution of Structured Language Model Programs" and opened new ground with a highly optimized backend runtime centered on **RadixAttention** and an efficient CPU scheduling design. Rather than discarding PagedAttention, RadixAttention extends it: it preserves as much prompt and generation KV cache as possible and attempts to reuse KV cache across requests; when prefixes match, it slashes prefill computation.
+
+![Community metrics for vLLM and SGLang](https://miro.medium.com/v2/resize:fit:1400/1*6Af9xaBJxWoTySjDr5Z8Sw.png)
+
+*(Current community metrics for both projects, data as of August 22, 2025)*
+
+Community-wise, SGLang is a fast-rising newcomer with a leaner footprint — its total contributor count is less than half of vLLM's. Most issues in vLLM receive responses within 12 hours to 3 days, whereas in SGLang it typically takes 3 to 5 days.
+
+### Origins: a continuous current of innovation
+
+As a leading U.S. public research university, UC Berkeley has produced a remarkable roster of open-source projects: Postgres in databases, RISC-V in hardware, Spark in big-data processing, and Ray in machine learning. Early core initiators of the two projects — [Woosuk Kwon](https://github.com/WoosukKwon) (vLLM) and [Lianmin Zheng](https://github.com/merrymercy) (SGLang) — both hail from Berkeley and studied under **Ion Stoica**, the luminary who led students to create **Spark** and **Ray**.
+
+vLLM led the way with an open-source release in June 2023; SGLang debuted roughly six months later. In 2023, Lianmin, Stanford's Ying Sheng, and several scholars founded the open research group [LMSYS.org](https://lmsys.org/), launching popular projects such as FastChat, Chatbot Arena, and Vicuna.
+
+Today, core initiators Woosuk and Lianmin remain actively involved. Recent six-month contributor data show that early-career academic researchers remain a major force. Beyond academia, **vLLM**'s contribution backbone includes **Red Hat**, while **SGLang**'s core contributors come from **xAI**, **Skywork**, **Oracle**, and **LinkedIn**.
+
+![Top contributors by organization](https://miro.medium.com/v2/resize:fit:1400/1*xN5pdifOp-MCTekQpax70Q.png)
+
+As many as **194** developers have contributed code to both **vLLM** and **SGLang** — about **30%** of SGLang's total code contributors to date. Notable cross-contributors include:
+
+- **comaniac** (OpenAI): 17 early PRs to SGLang + 77 PRs total to vLLM
+- **ShangmingCai** (Alibaba Cloud Feitian Lab): 18 PRs to vLLM, then shifted focus to SGLang with 52 PRs
+- **CatherineSue** (Oracle): 4 bug-fix PRs to vLLM, then 76 PRs to SGLang as a core contributor
+
+### Development, refactors, and fierce competition
+
+Key milestones from an OpenRank perspective:
+
+- **June 2023**: vLLM officially launches, introduces PagedAttention, and grows quickly.
+- **January 2024**: SGLang ships its first release and gains industry attention thanks to RadixAttention.
+- **July 2024**: SGLang releases v0.2, entering its first acceleration phase.
+- **September 2024**: vLLM ships v0.6.0, cutting latency ~5× and improving performance ~2.7× via CPU-scheduling and other optimizations; SGLang releases v0.3 the day before.
+- **December 2024–January 2025**: vLLM unveils the V1 refactor. With DeepSeek V3/R1 bursting onto the scene, both begin a second wave of explosive growth.
+
+![OpenRank comparison](https://miro.medium.com/v2/resize:fit:1400/0*c6h03uIaW2pcjTcU)
+
+In 2024, as features and hardware support expanded rapidly, vLLM hit classic software-engineering headwinds. A [third-party performance study](https://mlsys.wuklab.io/posts/scheduling_overhead/) published in September showed that in some scenarios vLLM's CPU scheduling overhead could exceed half of total inference time. The [official blog](https://blog.vllm.ai/2025/01/27/v1-alpha-release.html) acknowledged the need for a foundational refactor: **V1** arrived in early 2025, after which growth re-accelerated.
+
+![CPU scheduling overhead comparison](https://miro.medium.com/v2/resize:fit:1400/0*6HqK5za1-jUG6umX.png)
+
+*CPU scheduling overhead: vLLM (left) vs. SGLang (right)*
+
+In 2025, the performance race among inference engines heated up. Recognizing the limits of "number wars," both gradually shifted to reproducible methods and end-to-end metrics. A recent third-party comparison from Alibaba Cloud benchmarking vLLM vs. SGLang on the Qwen family showed overall single-GPU/dual-GPU results favoring SGLang, though outcomes vary across hardware/models/configurations.
+
+Trend-wise, model architectures are showing signs of convergence. Leaders vLLM and SGLang now both support Continuous Batching, PagedAttention, RadixAttention, Chunked Prefill, Speculative Decoding, Disaggregated Serving, and CUDA Graphs; operator libraries like FlashInfer, FlashAttention, and DeepGEMM.
+
+Other inference engines to watch:
+
+- **TensorRT-LLM**: launched by NVIDIA in late 2023, deeply tuned for its own hardware
+- **OpenVINO**: developed by Intel, focused on efficient deployment across Intel CPUs/GPUs
+- **Llama.cpp**: written in C++ by Georgi Gerganov in 2023, targets low-barrier edge inference
+- **LMDeploy**: co-developed by the MMDeploy and MMRazor teams, with dual backends — TurboMind for high performance and PyTorch for broad hardware coverage
+
+### Moving Forward in the Ecosystem
+
+During their rapid-growth phase, both **vLLM** and **SGLang** drew attention from investors and open-source foundations:
+
+- In August 2023, **a16z** launched the Open Source AI Grant, funding vLLM core developers **Woosuk Kwon** and **Zhuohan Li**. In a later cohort, SGLang core developers **Ying Sheng** and **Lianmin Zheng** were also funded.
+- In July 2024, **ZhenFund** donated to **vLLM**, and **LF AI & Data** announced vLLM's entry into incubation; this year vLLM was moved under the **PyTorch Foundation**.
+- In March 2025, PyTorch published a blog post welcoming **SGLang** to "the PyTorch ecosystem."
+
+Both projects have become go-to inference solutions globally, with active participation from engineers at Google, Meta, Microsoft, ByteDance, Alibaba, Tencent, and other companies.
+
+![Developer company backgrounds (issues)](https://miro.medium.com/v2/resize:fit:1400/0*XlEeoKV0LJda4r-D.png)
+
+*(Data Source: ossinsight) Company Backgrounds of Developers Submitting Issues*
+
+Today, roughly **33%** of **vLLM**'s contributors are based in China, and about **52%** for **SGLang**. Both communities host regular in-person meetups in Beijing, Shanghai, Shenzhen, and other cities worldwide.

--- a/src/pages/research.tsx
+++ b/src/pages/research.tsx
@@ -22,10 +22,6 @@ const LANDSCAPE_IMAGES = [
     src: "https://raw.githubusercontent.com/antgroup/llm-oss-landscape/main/reports/250913_llm_landscape/figures/llm_development_landscape.png",
     alt: "LLM Development Landscape",
   },
-  {
-    src: "https://raw.githubusercontent.com/antgroup/llm-oss-landscape/main/reports/250913_llm_landscape/figures/llm_development_landscape.png",
-    alt: "LLM Development Landscape",
-  },
 ];
 
 function LandscapeSlider() {
@@ -240,32 +236,18 @@ export default function Research(): ReactNode {
       </div>
 
       {/* Landscapes */}
-      {/* <div className={styles.hero}> */}
-        {/* <h2 className={styles.heroTitle}>Landscapes</h2>
+      <div className={styles.hero}>
+        <h2 className={styles.heroTitle}>Landscapes</h2>
         <p className={styles.heroText}>
           AI Infrastructure Landscapes and Insights Produced by InclusionAI,{" "}
           <br /> a comprehensive collection of AI infra projects, categorized
-          and analyzed to illuminate the evolving AI ecosystem. <br />
+          and analyzed to illuminate the evolving AI ecosystem.
         </p>
-        <p className={styles.heroText}>
-          These landscapes serve as a valuable resource for researchers,
-          practitioners, and enthusiasts to navigate the complex world of AI
-          infrastructure, fostering collaboration and innovation across the
-          field.
-        </p>
-        <LandscapeSlider />
-        <p className={styles.heroText}>
-          For more details, please visit the original repository:
-          <a
-            href="https://github.com/antgroup/llm-oss-landscape"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            GitHub Repository
-          </a>
-        </p> */}
 
-        {/* <div className={styles.papersList} id="landscape-news-list">
+        {/* Landscape slider */}
+        <LandscapeSlider />
+
+        <div className={styles.papersList} id="landscape-news-list">
           {landscapePosts.map((post) => (
             <Link
               key={post.permalink}
@@ -278,8 +260,19 @@ export default function Research(): ReactNode {
               </span>
             </Link>
           ))}
-        </div> */}
-      {/* </div> */}
+        </div>
+
+        <p className={styles.heroText}>
+          For more details, please visit the original &nbsp;
+          <a
+            href="https://github.com/antgroup/llm-oss-landscape"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub Repository
+          </a>
+        </p>
+      </div>
     </Layout>
   );
 }


### PR DESCRIPTION
- Created a new blog post for the AReaL v0.2 (Boba) release detailing major milestones, training speed comparisons, and future work.
- Added a blog post revisiting the Open Source LLM Development Landscape 2.0, highlighting new projects and global developer contributions.
- Introduced a blog post on the Open Source LLM Development 2025 landscape, trends, and insights, emphasizing the shift in AI's influence over other tech domains.
- Published a blog post discussing the community stories of vLLM and SGLang, focusing on their development, competition, and contributions.
- Updated the research page to include a landscape slider and improved the presentation of landscape insights and resources.